### PR TITLE
Avoid errors when doing code gen

### DIFF
--- a/include/public/xed/xed-init.h
+++ b/include/public/xed/xed-init.h
@@ -28,7 +28,7 @@ END_LEGAL */
 /// @ingroup INIT
 ///   This is the call to initialize the XED encode and decode tables. It
 ///   must be called once before using XED.
-void XED_DLL_EXPORT  xed_tables_init(void);
+XED_DLL_EXPORT void xed_tables_init(void);
 
 ////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Avoids error in `libclang v3.9.1` when using it for auto-generated code namely with [`bindgen`](https://crates.io/crates/bindgen) to generate rust bindings.

I see this declaration style elsewhere (namely `xed-util.h`) so I'm not sure why the style changed?